### PR TITLE
Fix table formatting on the Command Line Arguments Page

### DIFF
--- a/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
+++ b/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
@@ -101,7 +101,7 @@ the resolution with `++--dpi++`**
 allow version check (on/off or true/false for single launch). Note: if this option is not used, then it will check for
 new version, unless system preferences are set to disable it. This preference has to be created on "geogebra" key, with
 name "version_check_allow" (e.g. HKEY_LOCAL_MACHINE/Software/JavaSoft/Prefs/geogebra/version_check_allow in Windows
-registry ; edit the file /Library/Preferences/com.apple.java.util.prefs.plist in mac osx and add string key
+registry; edit the file /Library/Preferences/com.apple.java.util.prefs.plist in mac osx and add string key
 "version_check_allow" in Root > / > geogebra/), and value "false" if, on the computer, no check for new version is
 allowed.
 

--- a/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
+++ b/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
@@ -52,31 +52,31 @@ option.
 |`++--language=ISO_CODE++` |set language using http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes[locale code], e.g.
 en, de_AT
 
-|`++--showAlgebraInput=[true|false]++` |show/hide algebra xref:en@manual::/Input_Bar.adoc[Input Bar]
+|`++--showAlgebraInput=[true\|false]++` |show/hide algebra xref:en@manual::/Input_Bar.adoc[Input Bar]
 
-|`++--showAlgebraInputTop=[true|false]++` |Show algebra input field at top/bottom
+|`++--showAlgebraInputTop=[true\|false]++` |Show algebra input field at top/bottom
 
-|`++--showAlgebraWindow=[true|false]++` |show/hide xref:en@manual::/Algebra_View.adoc[Algebra View]
+|`++--showAlgebraWindow=[true\|false]++` |show/hide xref:en@manual::/Algebra_View.adoc[Algebra View]
 
-|`++--showSpreadsheet=[true|false]++` |show/hide xref:en@manual::/Spreadsheet_View.adoc[Spreadsheet View]
+|`++--showSpreadsheet=[true\|false]++` |show/hide xref:en@manual::/Spreadsheet_View.adoc[Spreadsheet View]
 
-|`++--showCAS=[true|false]++` |show/hide xref:en@manual::/CAS_View.adoc[CAS View]
+|`++--showCAS=[true\|false]++` |show/hide xref:en@manual::/CAS_View.adoc[CAS View]
 
-|`++--showSplash=[true|false]++` |show splash screen on startup
+|`++--showSplash=[true\|false]++` |show splash screen on startup
 
-|`++--enableUndo=[true|false]++` |enable/disable Undo
+|`++--enableUndo=[true\|false]++` |enable/disable Undo
 
 |`++--fontSize=[number]++` |set default font size
 
-|`++--showAxes=[true|false]++` |show/hide coordinate axes
+|`++--showAxes=[true\|false]++` |show/hide coordinate axes
 
-|`++--showGrid=[true|false]++` |show/hide coordinate grid
+|`++--showGrid=[true\|false]++` |show/hide coordinate grid
 
 |`++--settingsFile=FILENAME++` |load/save settings from/in a local file (used by the portable version)
 
 |`++--resetSettings++` |resets settings to defaults
 
-|`++--antiAliasing=[true|false]++` |turn antialiasing on (true) or off (false)
+|`++--antiAliasing=[true\|false]++` |turn antialiasing on (true) or off (false)
 
 |`++--export=<File>++` |Exports the Graphics View to SVG/PNG/PDF/EMF/EPS as determined by the extension**You can specify
 the resolution with `++--dpi++`**
@@ -87,13 +87,13 @@ the resolution with `++--dpi++`**
 
 |`++--dpi=<Integer>++` |dots per inch, eg 300 (only used in conjunction with `++--export++`)
 
-|`++--loop=[true|false]>++` |whether the animated GIF should repeat (only used in conjunction with
+|`++--loop=[true\|false]>++` |whether the animated GIF should repeat (only used in conjunction with
 `++--exportAnimation++`)
 
 |`++--delay=<Integer>++` |delay in ms between frames for the animated GIF (only used in conjunction with
 `++--exportAnimation++`)
 
-|`++--laf=<system|crossplatform>++` |Change the "Look and Feel" of the GUI
+|`++--laf=<system\|crossplatform>++` |Change the "Look and Feel" of the GUI
 
 |`++--versionCheckAllow++` a|
 allow version check (on/off or true/false for single launch). Note: if this option is not used, then it will check for

--- a/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
+++ b/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
@@ -101,7 +101,7 @@ the resolution with `++--dpi++`**
 allow version check (on/off or true/false for single launch). Note: if this option is not used, then it will check for
 new version, unless system preferences are set to disable it. This preference has to be created on "geogebra" key, with
 name "version_check_allow" (e.g. HKEY_LOCAL_MACHINE/Software/JavaSoft/Prefs/geogebra/version_check_allow in Windows
-registry ; edit the file /Library/Preferences/com.apple.java.util.prefs.plist in mac osx and add string key
+registry ; edit the file /Library/Preferences/com.apple.java.util.prefs.plist in mac osx and add string key
 "version_check_allow" in Root > / > geogebra/), and value "false" if, on the computer, no check for new version is
 allowed.
 

--- a/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
+++ b/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
@@ -80,11 +80,11 @@ en, de_AT
 
 |`++--antiAliasing=[true\|false]++` |turn antialiasing on (true) or off (false)
 
-|`++--export=<File>++` |Exports the Graphics View to SVG/PNG/PDF/EMF/EPS as determined by the extension**You can specify
+|`++--export=<File>++` |Exports the Graphics View to SVG/PNG/PDF/EMF/EPS as determined by the extension. **You can specify
 the resolution with `++--dpi++`**
 
 |`++--exportAnimation=<File>++` |Exports the Graphics View to mutiple SVG/PNG/PDF/EMF/EPS files (or one animated GIF) as
-determined by the extension and specified slider**You must specify the slider with `++--slider++` and you can specify
+determined by the extension and specified slider. **You must specify the slider with `++--slider++` and you can specify
 the resolution with `++--dpi++`**
 
 |`++--dpi=<Integer>++` |dots per inch, eg 300 (only used in conjunction with `++--export++`)

--- a/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
+++ b/reference/modules/ROOT/pages/Command_Line_Arguments.adoc
@@ -45,6 +45,8 @@ option.
 
 [width="100%",cols="50%,50%",]
 |===
+|Command Line Argument |Explanation
+
 |`++--help++` |print help message
 
 |`++--v++` |print version information, e.g. _GeoGebra 4.0.0.0 20 August 2011 Java 1.6.0_26_


### PR DESCRIPTION
The formatting for the table on the [Command Line Arguments](https://geogebra.github.io/docs/reference/en/Command_Line_Arguments/) page was quite off, so I fixed it.

**Before:**

(Markdown)

[![image](https://github.com/user-attachments/assets/b5800a4c-585c-4e75-a49b-99f7a434e0d3)](https://github.com/geogebra/integration/blob/main/reference/modules/ROOT/pages/Command_Line_Arguments.adoc#options)

(Website)

[![image](https://github.com/user-attachments/assets/0b498b0b-840d-408c-9864-65604e21696d)](https://geogebra.github.io/docs/reference/en/Command_Line_Arguments/#_options)

**After:**

[![image](https://github.com/user-attachments/assets/9f05dc61-9d0e-46fb-a85f-6afe079a4d2b)](https://github.com/esotericenderman/geogebra-math-apps/blob/fix-arguments-formatting/reference/modules/ROOT/pages/Command_Line_Arguments.adoc#options)

I used backslashes `\` to escape the pipe `|` characters so they wouldn't be interpreted as part of the table syntax.
